### PR TITLE
improve zooming

### DIFF
--- a/scenes/PlayerAndView.tscn
+++ b/scenes/PlayerAndView.tscn
@@ -3,17 +3,28 @@
 [ext_resource path="res://scripts/PlayerAndView.gd" type="Script" id=1]
 
 [sub_resource type="CylinderShape" id=1]
-height = 40.0
-radius = 100.0
+height = 50.0
+radius = 200.0
 
 [node name="Player" type="CSGBox"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0 )
 script = ExtResource( 1 )
+zoom_min_path = NodePath("ViewAnchor/ZoomMin")
+zoom_max_path = NodePath("ViewAnchor/ZoomMax")
+min_fov = 80.0
 
 [node name="ViewAnchor" type="Spatial" parent="."]
+transform = Transform( 0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, 0, 0, 0 )
 
 [node name="PlayerView" type="Camera" parent="ViewAnchor"]
-transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 5, 12 )
+transform = Transform( 1, 0, 0, 0, 0.939693, 0.34202, 0, -0.34202, 0.939693, 0, 4.947, 11.324 )
+far = 150.0
+
+[node name="ZoomMin" type="Position3D" parent="ViewAnchor"]
+transform = Transform( 1, 2.98023e-08, -2.98023e-08, 0, 0.939693, 0.34202, 0, -0.34202, 0.939693, -2.38419e-07, 2.28011, 6.08086 )
+
+[node name="ZoomMax" type="Position3D" parent="ViewAnchor"]
+transform = Transform( 1, 0, 0, 0, 0.35633, 0.93436, 0, -0.93436, 0.35633, 0, 58.9182, 23.9753 )
 
 [node name="Area" type="Area" parent="ViewAnchor"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
@@ -21,5 +32,5 @@ collision_layer = 2
 collision_mask = 2
 
 [node name="CollisionShape" type="CollisionShape" parent="ViewAnchor/Area"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 20, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 24, 0 )
 shape = SubResource( 1 )


### PR DESCRIPTION
Uses relative motion in pinch event (avoids steps when zooming)

Allows moving start and end point + rotation arbitrarily in the editor